### PR TITLE
Refactor/ngram class

### DIFF
--- a/corpus.py
+++ b/corpus.py
@@ -53,8 +53,8 @@ class corpus(object):
         print "Words occurring at least %s times: %s" % (wordcount_criterion, len(shortlist))
         return shortlist
 
-    def make_tree(self, string):
-        sentences = self.make_sentences(string)
+    def make_tree(self, str):
+        sentences = self.make_sentences(str)
         shortlist = self.short_list(sentences, self.wordcount_criterion)
 
         T = {}
@@ -95,9 +95,9 @@ class corpus(object):
         return T
 
     # splits the text into sentences, lowercases them and cleans punctuation
-    def make_sentences(self, string):
+    def make_sentences(self, str):
         # split at period followed by newline or space, or question mark, or exclamation point
-        sentences = string.split('.\n' or '. ' or '?' or '!')
+        sentences = str.split('.\n' or '. ' or '?' or '!')
 
         for sentence in range (0,len(sentences)):
             sentences[sentence] = sentences[sentence].strip('\n')
@@ -106,13 +106,13 @@ class corpus(object):
             sentences[sentence] = sentences[sentence].split()
         return sentences
 
-    def add_ngram(self, string, tree):
-        if string in tree:
-            tree[string].count += 1
+    def add_ngram(self, str, tree):
+        if str in tree:
+            tree[str].count += 1
         else:
-            tree[string] = Ngram(string)
-            tree[string].after = [{} for i in range(0,self.foresight)]
-            tree[string].before = [{} for i in range(0,self.hindsight)]
+            tree[str] = Ngram(str)
+            tree[str].after = [{} for i in range(0,self.foresight)]
+            tree[str].before = [{} for i in range(0,self.hindsight)]
 
     def lookup_ngram(self, ngram, tree):
         if ngram in tree:

--- a/corpus.py
+++ b/corpus.py
@@ -11,7 +11,7 @@ from collections import Counter
 """
 a corpus represents information about a text as a tree indexed by string
 	* each entry in the tree is an ngram object
-	* the key for a multi-word ngram is the space-separated words in the ngram	
+	* the key for a multi-word ngram is the space-separated words in the ngram
 """
 class corpus(object):
 
@@ -119,13 +119,13 @@ class corpus(object):
             return tree[ngram]
 
 
-    def get_before(self, key, distance=1, num_words = 20, sort_attribute="COUNT"):
+    def get_before(self, key, distance=1, num_words = 20, sort_attribute="count"):
         if key in self.tree:
             return self.tree[key].get_before(distance, num_words, sort_attribute)
         else:
             return []
 
-    def get_after(self, key, distance=1, num_words = 20, sort_attribute="COUNT"):
+    def get_after(self, key, distance=1, num_words = 20, sort_attribute="count"):
         if key in self.tree:
             return self.tree[key].get_after(distance, num_words, sort_attribute)
         else:
@@ -173,7 +173,7 @@ class corpus(object):
                 to_sort[ngram_key] = ngram.count
         return sorted(to_sort, key=operator.itemgetter(0))
 
-    def suggest(self, sentence, cursor_position, num_words, sort_attribute = "SIG_SCORE"):
+    def suggest(self, sentence, cursor_position, num_words, sort_attribute = "sig_score"):
 
         # these are the parts of the active sentence that come before and after the cursor
         before_cursor = sentence[0:cursor_position]
@@ -192,7 +192,7 @@ class corpus(object):
                     # crude function for privileging larger n-grams and closer contexts
                     weight = (10**n_gram_size)/(10**reach)
                     for tuple in after_previous:
-                        key = tuple[0].string
+                        key = tuple[0]
                         value = tuple[1] * weight
                         if len(key.split(' ')) == 1:
                             if key not in suggestions:
@@ -211,7 +211,7 @@ class corpus(object):
                     # crude function for privileging larger n-grams and closer contexts
                     weight = (10**n_gram_size)/(10**reach)
                     for tuple in before_next:
-                        key = tuple[0].string
+                        key = tuple[0]
                         value = tuple[1] * weight
                         if len(key.split(' ')) == 1:
                             if key not in suggestions:
@@ -222,7 +222,7 @@ class corpus(object):
         baseline_weight = 0.00000001
         for key in self.tree:
             n_gram = self.tree[key]
-            value = baseline_weight * n_gram.get_attribute(sort_attribute)
+            value = baseline_weight * getattr(n_gram, sort_attribute)
             if len(key.split(' ')) == 1:
                 if key not in suggestions:
                     suggestions[key] = value
@@ -244,7 +244,7 @@ class corpus(object):
 
     def __len__(self):
         return len(self.tree)
-    
+
     def fileToString(self, filename):
     	path = filename
     	f = open(path,"r")

--- a/corpus.py
+++ b/corpus.py
@@ -1,6 +1,6 @@
 __author__ = 'jamiebrew'
 
-import ngram
+from ngram import Ngram
 import string
 import math
 import operator
@@ -53,8 +53,8 @@ class corpus(object):
         print "Words occurring at least %s times: %s" % (wordcount_criterion, len(shortlist))
         return shortlist
 
-    def make_tree(self, str):
-        sentences = self.make_sentences(str)
+    def make_tree(self, string):
+        sentences = self.make_sentences(string)
         shortlist = self.short_list(sentences, self.wordcount_criterion)
 
         T = {}
@@ -95,9 +95,9 @@ class corpus(object):
         return T
 
     # splits the text into sentences, lowercases them and cleans punctuation
-    def make_sentences(self, str):
+    def make_sentences(self, string):
         # split at period followed by newline or space, or question mark, or exclamation point
-        sentences = str.split('.\n' or '. ' or '?' or '!')
+        sentences = string.split('.\n' or '. ' or '?' or '!')
 
         for sentence in range (0,len(sentences)):
             sentences[sentence] = sentences[sentence].strip('\n')
@@ -106,13 +106,13 @@ class corpus(object):
             sentences[sentence] = sentences[sentence].split()
         return sentences
 
-    def add_ngram(self, str, tree):
-        if str in tree:
-            tree[str].count += 1
+    def add_ngram(self, string, tree):
+        if string in tree:
+            tree[string].count += 1
         else:
-            tree[str] = ngram.ngram(str)
-            tree[str].after = [{} for i in range(0,self.foresight)]
-            tree[str].before = [{} for i in range(0,self.hindsight)]
+            tree[string] = Ngram(string)
+            tree[string].after = [{} for i in range(0,self.foresight)]
+            tree[string].before = [{} for i in range(0,self.hindsight)]
 
     def lookup_ngram(self, ngram, tree):
         if ngram in tree:

--- a/ngram.py
+++ b/ngram.py
@@ -1,7 +1,5 @@
 __author__ = 'jamiebrew'
 
-import operator
-
 # information about a unique string within a corpus
 class ngram(object):
 
@@ -11,50 +9,44 @@ class ngram(object):
         self.after = []                 # list of dictionaries
         self.before = []                # list of dictionaries
         self.frequency = 0              # normalized rate of occurrence
-        self.sig_score = 0                    # significance score
+        self.sig_score = 0              # significance score
         self.rhymes = {}
 
     def __str__(self):
-        return self.string+"\ncount: "+str(self.count)+"\nfreq: "+str(self.frequency)+"\nsig: "+str(self.sig_score)+'\n'
+        return "{string}\n" + \
+               "count: {count}\n" + \
+               "freq: {frequency}\n" + \
+               "sig: {sig_score}\n".format(**vars(self))
 
     def __repr__(self):
         return self.string
-    
+
     def __len__(self):
-    	return len(self.string)
+        return len(self.string)
 
     # returns top n words occuring distance after this ngram
-    def get_after(self, distance=1, n=20, sort_attribute="COUNT"):
-        dictionary = self.after[distance-1]
-        #print 'top %s words occuring %s after "%s":' % (n, distance, self.string)
-        word_list = [] #TODO: cleaner way to do this
-        for key in dictionary:
-            if sort_attribute == "COUNT":
-                word_list.append((dictionary[key], dictionary[key].count))
-            elif sort_attribute == "FREQUENCY":
-                word_list.append((dictionary[key], dictionary[key].frequency))
-            elif sort_attribute == "SIG_SCORE":
-                word_list.append((dictionary[key], dictionary[key].sig_score))
-        return list(reversed(sorted(word_list, key=lambda tup: tup[1])))[0:n]
+    def get_after(self, distance=1, n=20, sort_attribute="count"):
+        return self._get_ngram_and_attribute(distance, n, sort_attribute, True)
 
     # returns top n words occuring distance before this ngram
-    def get_before(self, distance=1, n=20, sort_attribute="COUNT"):
-        dictionary = self.before[distance-1]
-        #print 'top %s words occuring %s before "%s":' % (n, distance, self.string)
-        word_list = [] #TODO: cleaner way to do this
-        for key in dictionary:
-            if sort_attribute == "COUNT":
-                word_list.append((dictionary[key], dictionary[key].count))
-            elif sort_attribute == "FREQUENCY":
-                word_list.append((dictionary[key], dictionary[key].frequency))
-            elif sort_attribute == "SIG_SCORE":
-                word_list.append((dictionary[key], dictionary[key].sig_score))
-        return list(reversed(sorted(word_list, key=lambda tup: tup[1])))[0:n]
+    def get_before(self, distance=1, n=20, sort_attribute="count"):
+        return self._get_ngram_and_attribute(distance, n, sort_attribute, False)
 
-    def get_attribute(self, sort_attribute):
-        if sort_attribute == "COUNT":
-            return self.count
-        elif sort_attribute == "FREQUENCY":
-            return self.frequency
-        elif sort_attribute == "SIG_SCORE":
-            return self.sig_score
+    def _get_ngram_and_attribute(self, distance, n, sort_attribute, is_after):
+        distance -= 1
+        dictionary = self.after[distance] if is_after else self.before[distance]
+
+        return list(
+            reversed(
+                sorted(
+                    map(
+                        lambda (string, ngram): (
+                            string,
+                            getattr(ngram, sort_attribute)
+                        ),
+                        dictionary.iteritems()
+                    ),
+                    key=lambda tuple: tuple[1]
+                )
+            )
+        )[0:n]

--- a/ngram.py
+++ b/ngram.py
@@ -1,7 +1,7 @@
 __author__ = 'jamiebrew'
 
 # information about a unique string within a corpus
-class ngram(object):
+class Ngram(object):
 
     def __init__(self, string):
         self.string = string

--- a/voice.py
+++ b/voice.py
@@ -12,7 +12,7 @@ class voice(object):
         for path, name, weight in paths_names_weights:
             self.weighted_corpora[name] = [corpus.corpus(path, name), weight]
 
-    def suggest(self, sentence, cursor_position, num_words, sort_attribute = "FREQUENCY"):
+    def suggest(self, sentence, cursor_position, num_words, sort_attribute = "frequency"):
         suggestions = {}
         for key in self.weighted_corpora:
             corpus, weight = self.weighted_corpora[key]


### PR DESCRIPTION
A little bit of refactoring to use the `getattr` (https://docs.python.org/2/library/functions.html#getattr) method instead of a switch statement. The `get_after` and `get_before` methods are now functional one-liners and no longer store the Ngram object, just the necessary attributes. It's a little less readable and I'm open to reverting it.